### PR TITLE
Add `@honor` namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "moment-round",
+  "name": "@honor/moment-round",
   "version": "1.0.1",
   "description": "Date rounding for Moment.js",
   "keywords": [ "moment", "moment.js", "date", "round" ],


### PR DESCRIPTION
This is our new pattern for internal javascript packages. The `@honor` prefix ensures that we can configure npm/yarn to speak to our codeartifact repository for these packages. See
https://github.com/joinhonor/apache-thrift/pull/16 for more details.

For the record, I've already published this to our package server. Here's the command I used to do that:

    aws-vault exec honor -- aws codeartifact login --tool npm --domain honorcare --repository honorcare-prod --region us-west-2 --namespace=@honor && npm publish